### PR TITLE
Added support for Windows; Added support for names with length up to 16

### DIFF
--- a/random_art/randomart.py
+++ b/random_art/randomart.py
@@ -44,8 +44,8 @@ TRANSLATION = {
 
 # draw characters in a box
 def draw(matrix, name, palette=PALETTE):
-    if len(name) != 10:
-        raise ValueError("name must be 10 characters")
+    if len(name) > 18:
+        raise ValueError("name can't be more 16 characters")
     # pick n'th character from palette
     symbol = lambda n: PALETTE[n % len(PALETTE)]
     # write randomart to string buffer line by line
@@ -53,5 +53,5 @@ def draw(matrix, name, palette=PALETTE):
     art.write("╭──╴randomart.py╶──╮\n")
     for line in matrix:
         art.write("│%s│\n" % "".join((symbol(el) for el in line)))
-    art.write("╰───╴%s╶───╯\n" % name)
+    art.write("╰" + '─'*int(8 - len(name)/2) + '╴' + name + '╶' + '─'*(8 - len(name)//2) + "╯\n")  # dynamically calculate dashes for name
     return art.getvalue()

--- a/random_art/randomart.py
+++ b/random_art/randomart.py
@@ -44,7 +44,7 @@ TRANSLATION = {
 
 # draw characters in a box
 def draw(matrix, name, palette=PALETTE):
-    if len(name) > 18:
+    if len(name) > 16:
         raise ValueError("name can't be more 16 characters")
     # pick n'th character from palette
     symbol = lambda n: PALETTE[n % len(PALETTE)]

--- a/randomart.py
+++ b/randomart.py
@@ -21,7 +21,7 @@ parser = argparse.ArgumentParser(
 # the input file to be hashed
 parser.add_argument("file",
     type=argparse.FileType("rb"),
-    default=None,
+    default=sys.stdin.buffer,
     nargs="?",
     help="input file (default: stdin)",
 )
@@ -41,16 +41,8 @@ parser.add_argument("--hash",
 # parse commandline
 args = parser.parse_args()
 
-if args.file is None:  # no input file was specified
-    import os
-    if os.name == 'posix':  # Linux and macOS
-        file = "/dev/stdin"
-    elif os.name == 'nt':   # Windows
-        import sys
-        file = sys.stdin.buffer.raw
-
 # hash the file
-digest = crypto.digest(file)
+digest = crypto.digest(args.file)
 
 # maybe print encoded digest
 if args.hash:

--- a/randomart.py
+++ b/randomart.py
@@ -21,7 +21,7 @@ parser = argparse.ArgumentParser(
 # the input file to be hashed
 parser.add_argument("file",
     type=argparse.FileType("rb"),
-    default="/dev/stdin",
+    default=None,
     nargs="?",
     help="input file (default: stdin)",
 )
@@ -41,8 +41,16 @@ parser.add_argument("--hash",
 # parse commandline
 args = parser.parse_args()
 
+if args.file is None:  # no input file was specified
+    import os
+    if os.name == 'posix':  # Linux and macOS
+        file = "/dev/stdin"
+    elif os.name == 'nt':   # Windows
+        import sys
+        file = sys.stdin.buffer.raw
+
 # hash the file
-digest = crypto.digest(args.file)
+digest = crypto.digest(file)
 
 # maybe print encoded digest
 if args.hash:


### PR DESCRIPTION
Updated randomart.py (the one in root) to instead have `None` as default value for `file`. After parsing arguments, a piece of code checks for `None` and replaces with `"/dev/stdin"` for Linux and MacOS or `sys.stdin.buffer.raw` for Windows, since the former does not work on Windows.

Updated random_art/randomart.py to dynamically calculate spacing and box characters to correctly display name of any length up to 16. Earlier versions only supported names of length exactly 10.